### PR TITLE
Replace Time.now with Time.current

### DIFF
--- a/lib/api_auth/base.rb
+++ b/lib/api_auth/base.rb
@@ -74,7 +74,7 @@ module ApiAuth
 
       timestamp = DateTime.strptime(headers.timestamp, ApiAuth.configuration.date_format)
       time = Time.local(timestamp.year, timestamp.month, timestamp.day, timestamp.hour, timestamp.min, timestamp.sec)
-      time.utc < (Time.now.utc - 900)
+      time.utc < (Time.current.utc - 900)
     rescue ArgumentError
       true
     end

--- a/lib/api_auth/request_drivers/action_controller.rb
+++ b/lib/api_auth/request_drivers/action_controller.rb
@@ -51,7 +51,7 @@ module ApiAuth
       end
 
       def set_date
-        @request.env["HTTP_#{ApiAuth.configuration.date_header}"] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request.env["HTTP_#{ApiAuth.configuration.date_header}"] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 

--- a/lib/api_auth/request_drivers/curb.rb
+++ b/lib/api_auth/request_drivers/curb.rb
@@ -39,7 +39,7 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request.headers[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 

--- a/lib/api_auth/request_drivers/faraday.rb
+++ b/lib/api_auth/request_drivers/faraday.rb
@@ -54,7 +54,7 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request.headers[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 

--- a/lib/api_auth/request_drivers/httpi.rb
+++ b/lib/api_auth/request_drivers/httpi.rb
@@ -50,7 +50,7 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request.headers[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 

--- a/lib/api_auth/request_drivers/net_http.rb
+++ b/lib/api_auth/request_drivers/net_http.rb
@@ -58,7 +58,7 @@ module ApiAuth
       end
 
       def set_date
-        @request[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 

--- a/lib/api_auth/request_drivers/rack.rb
+++ b/lib/api_auth/request_drivers/rack.rb
@@ -56,7 +56,7 @@ module ApiAuth
       end
 
       def set_date
-        @request.env[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request.env[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         fetch_headers
       end
 

--- a/lib/api_auth/request_drivers/rest_client.rb
+++ b/lib/api_auth/request_drivers/rest_client.rb
@@ -59,7 +59,7 @@ module ApiAuth
       end
 
       def set_date
-        @request.headers[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+        @request.headers[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
         save_headers
       end
 

--- a/spec/api_auth_spec.rb
+++ b/spec/api_auth_spec.rb
@@ -60,7 +60,7 @@ describe 'ApiAuth' do
         Net::HTTP::Put.new('/resource.xml?foo=bar&bar=foo',
                            'content-type' => 'text/plain',
                            'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
-                           ApiAuth.configuration.date_header => Time.now.utc.strftime(ApiAuth.configuration.date_format)
+                           ApiAuth.configuration.date_header => Time.current.utc.strftime(ApiAuth.configuration.date_format)
                           )
       end
 
@@ -95,7 +95,7 @@ describe 'ApiAuth' do
       new_request = Net::HTTP::Put.new('/resource.xml?foo=bar&bar=foo',
                                        'content-type' => 'text/plain',
                                        'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
-                                       ApiAuth.configuration.date_header => Time.now.utc.strftime(ApiAuth.configuration.date_format)
+                                       ApiAuth.configuration.date_header => Time.current.utc.strftime(ApiAuth.configuration.date_format)
                                       )
 
       signature = hmac('123', new_request)
@@ -147,7 +147,7 @@ describe 'ApiAuth' do
         new_request = Net::HTTP::Put.new('/resource.xml?foo=bar&bar=foo',
                                          'content-type' => 'text/plain',
                                          'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
-                                         ApiAuth.configuration.date_header => Time.now.utc.strftime(ApiAuth.configuration.date_format)
+                                         ApiAuth.configuration.date_header => Time.current.utc.strftime(ApiAuth.configuration.date_format)
                                         )
         canonical_string = ApiAuth::Headers.new(new_request).canonical_string
         signature = hmac('123', new_request, canonical_string, 'sha256')
@@ -181,7 +181,7 @@ describe 'ApiAuth' do
           new_request = Net::HTTP::Put.new('/resource.xml?foo=bar&bar=foo',
                                            'content-type' => 'text/plain',
                                            'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
-                                           ApiAuth.configuration.date_header => Time.now.utc.strftime(ApiAuth.configuration.date_format)
+                                           ApiAuth.configuration.date_header => Time.current.utc.strftime(ApiAuth.configuration.date_format)
                                           )
 
           signature = ApiAuth.configuration.signer.sign(ApiAuth::Headers.new(new_request), '123', :digest => 'sha1')
@@ -203,7 +203,7 @@ describe 'ApiAuth' do
           new_request = Net::HTTP::Put.new('http://google.com',
                                            'content-type' => 'text/plain',
                                            'content-md5' => '1B2M2Y8AsgTpgAmY7PhCfg==',
-                                           ApiAuth.configuration.date_header => Time.now.utc.strftime(ApiAuth.configuration.date_format)
+                                           ApiAuth.configuration.date_header => Time.current.utc.strftime(ApiAuth.configuration.date_format)
                                           )
 
           signature = ApiAuth.configuration.signer.sign(ApiAuth::Headers.new(new_request), '123', :digest => 'sha1')

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -63,7 +63,7 @@ describe 'Rails integration' do
 
     it 'should permit a request with properly signed headers' do
       request = ActionController::TestRequest.new
-      request.env[ApiAuth.configuration.date_header] = Time.now.utc.strftime(ApiAuth.configuration.date_format)
+      request.env[ApiAuth.configuration.date_header] = Time.current.utc.strftime(ApiAuth.configuration.date_format)
       ApiAuth.sign!(request, '1044', API_KEY_STORE['1044'])
       response = generated_response(request, :index)
       expect(response.code).to eq('200')

--- a/spec/request_drivers/action_controller_spec.rb
+++ b/spec/request_drivers/action_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 if defined?(ActionController::Request)
 
   describe ApiAuth::RequestDrivers::ActionControllerRequest do
-    let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+    let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
     let(:request) do
       ActionController::Request.new(

--- a/spec/request_drivers/action_dispatch_spec.rb
+++ b/spec/request_drivers/action_dispatch_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 if defined?(ActionDispatch::Request)
 
   describe ApiAuth::RequestDrivers::ActionDispatchRequest do
-    let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+    let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
     let(:request) do
       ActionDispatch::Request.new(

--- a/spec/request_drivers/curb_spec.rb
+++ b/spec/request_drivers/curb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::CurbRequest do
-  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+  let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request) do
     headers = {

--- a/spec/request_drivers/faraday_spec.rb
+++ b/spec/request_drivers/faraday_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::FaradayRequest do
-  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+  let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:faraday_stubs) do
     Faraday::Adapter::Test::Stubs.new do |stub|

--- a/spec/request_drivers/httpi_spec.rb
+++ b/spec/request_drivers/httpi_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::HttpiRequest do
-  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+  let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request) do
     httpi_request = HTTPI::Request.new('http://localhost/resource.xml?foo=bar&bar=foo')

--- a/spec/request_drivers/net_http_spec.rb
+++ b/spec/request_drivers/net_http_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::NetHttpRequest do
-  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+  let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request_path) { '/resource.xml?foo=bar&bar=foo' }
 

--- a/spec/request_drivers/rack_spec.rb
+++ b/spec/request_drivers/rack_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::RackRequest do
-  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+  let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request_path) { '/resource.xml?foo=bar&bar=foo' }
 

--- a/spec/request_drivers/rest_client_spec.rb
+++ b/spec/request_drivers/rest_client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApiAuth::RequestDrivers::RestClientRequest do
-  let(:timestamp) { Time.now.utc.strftime(ApiAuth.configuration.date_format) }
+  let(:timestamp) { Time.current.utc.strftime(ApiAuth.configuration.date_format) }
 
   let(:request_path) { '/resource.xml?foo=bar&bar=foo' }
 


### PR DESCRIPTION
We should **NOT** be using [`Time.now`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/time_zone.rb#L18-L30).